### PR TITLE
fix: Fix NRF URL changing to an IP after initial registration

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,9 +14,9 @@ parts:
     plugin: go
     source: https://github.com/omec-project/udr.git
     source-type: git
-    source-commit: 35eb7b763feff22dc9766b6ce6e3a23ea8151759
+    source-commit: 653cefd60a464c3e9ea898657837331ef3ebc1aa
     build-snaps:
-      - go/1.18/stable
+      - go/1.21/stable
     stage-packages:
       - libc6_libs
     organize:


### PR DESCRIPTION
# Description

Fix NRF URL changing to the IP of the replying NRF after initial registration, causing issues if the NRF crashes and changes IP.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
