### PR TITLE
chore: bump build base to ubuntu 24.04

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: sdcore-udr
 base: bare
-build-base: ubuntu@22.04
+build-base: ubuntu@24.04
 version: '1.4.0'
 summary: SD-Core UDR
 description: SD-Core UDR
@@ -19,5 +19,6 @@ parts:
       - go/1.21/stable
     stage-packages:
       - libc6_libs
+      - base-files_lib
     organize:
       bin/cmd: bin/udr


### PR DESCRIPTION
# Description

Bump the build base to Ubuntu 24.04. Here we also need to include the base-files_lib slice because starting Ubuntu 24.04, the 'base-files' package provides "bin" as a symlink to "usr/bin".

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
