### PR TITLE
chore: Update CI triggers to not duplicate CI runs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,9 +2,14 @@ name: Main
 
 on:
   pull_request:
+    types: [edited, opened, reopened, synchronize]
     branches:
       - main
+      - v**
   push:
+    branches:
+      - main
+      - v**
   schedule:
     - cron: '0 0 * * 0'
 


### PR DESCRIPTION
# Description

Changes the events that trigger the CI to only run a single copy of a job on PRs (instead of 1 for pr and 1 for push). Also ensures the CI runs on PRs targeting release branches, and when merging to main or release branches.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
